### PR TITLE
feat(client): add dismissible mobile warning banner

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -4,6 +4,7 @@ import { useI18n } from 'vue-i18n'
 import analytics from '@client/analytics'
 import Alerts from '@client/components/alert/Alerts.vue'
 import AppFooter from '@client/components/common/AppFooter.vue'
+import MobileBanner from '@client/components/common/MobileBanner.vue'
 import ScreenReaderAnnouncer from '@client/components/common/ScreenReaderAnnouncer.vue'
 
 const { t } = useI18n()
@@ -22,6 +23,7 @@ onMounted(() => {
 		>
 			{{ t('common.skipToContent') }}
 		</a>
+		<MobileBanner />
 		<RouterView class="flex-1" />
 		<AppFooter />
 		<Alerts />

--- a/client/src/components/common/MobileBanner.vue
+++ b/client/src/components/common/MobileBanner.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import IconMonitor from '~icons/lucide/monitor'
+import IconX from '~icons/lucide/x'
+
+const DISMISSED_KEY = 'kreditozrouti:mobile-banner-dismissed'
+const visible = ref(localStorage.getItem(DISMISSED_KEY) !== 'true')
+
+function dismiss() {
+	localStorage.setItem(DISMISSED_KEY, 'true')
+	visible.value = false
+}
+</script>
+
+<template>
+	<div
+		v-if="visible"
+		class="md:hidden flex items-center gap-3 bg-(--insis-blue) px-4 py-3 text-sm text-white"
+		role="banner"
+	>
+		<IconMonitor class="h-4 w-4 shrink-0 opacity-80" aria-hidden="true" />
+		<span class="flex-1">{{ $t('common.mobileBanner.message') }}</span>
+		<button
+			type="button"
+			class="shrink-0 opacity-70 hover:opacity-100 transition-opacity"
+			:aria-label="$t('common.close')"
+			@click="dismiss"
+		>
+			<IconX class="h-4 w-4" />
+		</button>
+	</div>
+</template>

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -185,6 +185,9 @@
 		"removeTimeFilter": "Odebrat časový filtr",
 		"closeCourseModal": "Zavřít detail předmětu",
 		"switchLanguage": "Změnit jazyk",
+		"mobileBanner": {
+			"message": "Kreditožrouti je optimalizován pro počítač. Pro nejlepší zážitek doporučujeme použít PC."
+		},
 		"announcements": {
 			"coursesFound": "Nalezen {count} kurz | Nalezeny {count} kurzy | Nalezeno {count} kurzů",
 			"noCoursesFound": "Nebyly nalezeny žádné kurzy",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -185,6 +185,9 @@
 		"removeTimeFilter": "Remove time filter",
 		"closeCourseModal": "Close course details",
 		"switchLanguage": "Switch language",
+		"mobileBanner": {
+			"message": "Kreditožrouti is optimized for desktop. For the best experience, we recommend using a PC."
+		},
 		"announcements": {
 			"coursesFound": "Found {count} course | Found {count} courses",
 			"noCoursesFound": "No courses found",


### PR DESCRIPTION
﻿## Summary

- Adds a blue banner at the top of every page on mobile viewports under 768px
- Text: "Kreditozrouti is optimized for desktop. For the best experience, we recommend using a PC." (EN/CS)
- Dismissible via X button; dismissal persists in localStorage (kreditozrouti:mobile-banner-dismissed) so it does not reappear
- Hidden on desktop via md:hidden - no JS viewport detection needed

New file: MobileBanner.vue added to App.vue above the RouterView.

## Test plan

- [ ] Open the app on a mobile viewport under 768px - banner appears at the top
- [ ] Click X - banner disappears and does not reappear on reload
- [ ] Open on desktop 768px or wider - banner not visible
- [ ] Switch language - message appears in correct language

Closes #75

Generated with Claude Code https://claude.com/claude-code
