### PR TITLE
feat(client): show lecturer in timetable modal (#93)

### DIFF
--- a/api/src/Jobs/ScraperResponseInSISCourseJob.ts
+++ b/api/src/Jobs/ScraperResponseInSISCourseJob.ts
@@ -273,11 +273,7 @@ async function syncStudyPlansFromCourse(courseId: number, courseIdent: string, c
  * No-ops silently when the course is not present in the DB.
  */
 async function deleteCourse(courseId: number): Promise<void> {
-	const existing = await mysql
-		.selectFrom(CourseTable._table)
-		.select('id')
-		.where('id', '=', courseId)
-		.executeTakeFirst()
+	const existing = await mysql.selectFrom(CourseTable._table).select('id').where('id', '=', courseId).executeTakeFirst()
 
 	if (!existing) {
 		LoggerJobContext.add({ skipped_not_in_db: true })
@@ -285,11 +281,7 @@ async function deleteCourse(courseId: number): Promise<void> {
 	}
 
 	await mysql.transaction().execute(async trx => {
-		const units = await trx
-			.selectFrom(CourseUnitTable._table)
-			.select('id')
-			.where('course_id', '=', courseId)
-			.execute()
+		const units = await trx.selectFrom(CourseUnitTable._table).select('id').where('course_id', '=', courseId).execute()
 
 		const unitIds = units.map(u => u.id)
 
@@ -303,10 +295,7 @@ async function deleteCourse(courseId: number): Promise<void> {
 		await trx.deleteFrom(CourseTable._table).where('id', '=', courseId).execute()
 	})
 
-	await redis.publish(
-		`course:updated:${courseId}`,
-		JSON.stringify({ status: 'deleted', courseId, updatedAt: new Date().toISOString() })
-	)
+	await redis.publish(`course:updated:${courseId}`, JSON.stringify({ status: 'deleted', courseId, updatedAt: new Date().toISOString() }))
 
 	await flushResponseCaches()
 

--- a/client/src/components/timetable/TimetableCourseModal.vue
+++ b/client/src/components/timetable/TimetableCourseModal.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 /**
  * TimetableCourseModal
  *
@@ -23,7 +23,6 @@ import IconMinus from '~icons/lucide/minus'
 import IconPlus from '~icons/lucide/plus'
 import IconSearch from '~icons/lucide/search'
 import IconTrash from '~icons/lucide/trash-2'
-import IconUser from '~icons/lucide/user'
 import IconX from '~icons/lucide/x'
 
 const { t } = useI18n()
@@ -149,7 +148,7 @@ watch(() => props.unit.courseId, fetchCourse, { immediate: true })
 
 function handleSearchInTimeslot() {
 	// Apply time filter for this slot
-	filtersStore.filters.include_times = [{ day: props.unit.day ?? 'Pondělí', time_from: props.unit.timeFrom, time_to: props.unit.timeTo }]
+	filtersStore.filters.include_times = [{ day: props.unit.day ?? 'PondÄ›lÃ­', time_from: props.unit.timeFrom, time_to: props.unit.timeTo }]
 	filtersStore.filters.offset = 0
 
 	// Switch to list view
@@ -302,10 +301,7 @@ onUnmounted(() => {
 										<span>{{ unit.location }}</span>
 									</div>
 									<div v-if="unit.lecturer" class="flex items-center justify-between">
-										<span class="flex items-center gap-1 text-(--insis-gray-500)">
-											<IconUser class="h-3.5 w-3.5" />
-											{{ $t('components.timetable.TimetableCourseModal.lecturer') }}
-										</span>
+										<span class="text-(--insis-gray-500)">{{ $t('components.timetable.TimetableCourseModal.lecturer') }}:</span>
 										<span class="font-medium">{{ unit.lecturer }}</span>
 									</div>
 								</div>
@@ -356,6 +352,9 @@ onUnmounted(() => {
 														<span class="font-medium">{{ formatSlotInfo(slot) }}</span>
 														<span class="truncate text-(--insis-gray-600)">{{ slot.location || '-' }}</span>
 													</div>
+													<div v-if="courseUnit.lecturer" class="pl-[44px] text-xs text-(--insis-gray-500)">
+														{{ courseUnit.lecturer }}
+													</div>
 
 													<div v-if="courseUnit.capacity !== undefined" class="mt-1 pl-[44px]">
 														<span :class="['text-xs', getCapacityClass(courseUnit.capacity)]">
@@ -363,7 +362,7 @@ onUnmounted(() => {
 														</span>
 													</div>
 
-													<!-- Conflict status badge — full width below slot info -->
+													<!-- Conflict status badge â€” full width below slot info -->
 													<div
 														v-if="
 															unitConflictStatuses[courseUnit.id]?.type === 'conflict' ||
@@ -373,7 +372,7 @@ onUnmounted(() => {
 													>
 														<template v-if="unitConflictStatuses[courseUnit.id]?.type === 'conflict'">
 															<span class="insis-badge insis-badge-danger text-xs">
-																⚠
+																âš 
 																{{
 																	$t('components.timetable.TimetableCourseModal.slotConflict', {
 																		ident: (unitConflictStatuses[courseUnit.id] as { type: 'conflict'; ident: string })
@@ -384,7 +383,7 @@ onUnmounted(() => {
 														</template>
 														<template v-else-if="unitConflictStatuses[courseUnit.id]?.type === 'campus'">
 															<span class="insis-badge insis-badge-warning text-xs">
-																🏫
+																ðŸ«
 																{{
 																	$t('components.timetable.TimetableCourseModal.slotCampusConflict', {
 																		ident: (unitConflictStatuses[courseUnit.id] as { type: 'campus'; ident: string }).ident,

--- a/client/src/components/timetable/TimetableCourseModal.vue
+++ b/client/src/components/timetable/TimetableCourseModal.vue
@@ -23,6 +23,7 @@ import IconMinus from '~icons/lucide/minus'
 import IconPlus from '~icons/lucide/plus'
 import IconSearch from '~icons/lucide/search'
 import IconTrash from '~icons/lucide/trash-2'
+import IconUser from '~icons/lucide/user'
 import IconX from '~icons/lucide/x'
 
 const { t } = useI18n()
@@ -299,6 +300,13 @@ onUnmounted(() => {
 									<div v-if="unit.location" class="flex items-center justify-between">
 										<span class="text-(--insis-gray-500)">{{ $t('common.location') }}:</span>
 										<span>{{ unit.location }}</span>
+									</div>
+									<div v-if="unit.lecturer" class="flex items-center justify-between">
+										<span class="flex items-center gap-1 text-(--insis-gray-500)">
+											<IconUser class="h-3.5 w-3.5" />
+											{{ $t('components.timetable.TimetableCourseModal.lecturer') }}
+										</span>
+										<span class="font-medium">{{ unit.lecturer }}</span>
 									</div>
 								</div>
 							</div>

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -456,7 +456,8 @@
 				"filterDescription": "Zobrazuji předměty dostupné v {day} od {from} do {to}",
 				"slotFree": "Volný",
 				"slotConflict": "Konflikt: {ident}",
-				"slotCampusConflict": "Kampus: {ident}"
+				"slotCampusConflict": "Kampus: {ident}",
+				"lecturer": "Vyučující"
 			},
 			"SchedulePicker": {
 				"title": "Uložené rozvrhy",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -456,7 +456,8 @@
 				"filterDescription": "Showing courses available on {day} from {from} to {to}",
 				"slotFree": "Free",
 				"slotConflict": "Conflict: {ident}",
-				"slotCampusConflict": "Campus: {ident}"
+				"slotCampusConflict": "Campus: {ident}",
+				"lecturer": "Lecturer"
 			},
 			"SchedulePicker": {
 				"title": "Saved Schedules",


### PR DESCRIPTION
## Summary

- Adds lecturer name row to the Selected Slot section of `TimetableCourseModal`
- Only shown when `unit.lecturer` is present (unit-level data from InSIS)
- Uses `IconUser` Lucide icon consistent with existing slot details layout
- i18n keys added for both `en` and `cs` locales

## Test plan

- [ ] Open timetable, click a course slot that has a lecturer assigned — verify "Lecturer" row appears with the name
- [ ] Click a slot without a unit-level lecturer — verify row is hidden
- [ ] Switch language to Czech — verify label shows "Vyučující"

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)