### PR TITLE
fix(api,scraper): delete ghost courses when InSIS signals not-found (#95)

### DIFF
--- a/api/src/Jobs/ScraperResponseInSISCourseJob.ts
+++ b/api/src/Jobs/ScraperResponseInSISCourseJob.ts
@@ -35,7 +35,16 @@ export default async function ScraperResponseInSISCourseJob(data: ScraperInSISCo
 		course_ident: course?.ident
 	})
 
-	if (!course?.id) {
+	if (course === null) {
+		if (data.course_id) {
+			await deleteCourse(data.course_id)
+		} else {
+			LoggerJobContext.add({ skipped_no_id: true })
+		}
+		return
+	}
+
+	if (!course.id) {
 		LoggerJobContext.add({ skipped_no_id: true })
 		return
 	}
@@ -256,6 +265,52 @@ async function syncStudyPlansFromCourse(courseId: number, courseIdent: string, c
 	}
 
 	return planEntries.length
+}
+
+/**
+ * Deletes a ghost course and all its child rows when InSIS signals it no longer exists.
+ * Runs inside a transaction to maintain referential integrity.
+ * No-ops silently when the course is not present in the DB.
+ */
+async function deleteCourse(courseId: number): Promise<void> {
+	const existing = await mysql
+		.selectFrom(CourseTable._table)
+		.select('id')
+		.where('id', '=', courseId)
+		.executeTakeFirst()
+
+	if (!existing) {
+		LoggerJobContext.add({ skipped_not_in_db: true })
+		return
+	}
+
+	await mysql.transaction().execute(async trx => {
+		const units = await trx
+			.selectFrom(CourseUnitTable._table)
+			.select('id')
+			.where('course_id', '=', courseId)
+			.execute()
+
+		const unitIds = units.map(u => u.id)
+
+		if (unitIds.length > 0) {
+			await trx.deleteFrom(CourseUnitSlotTable._table).where('unit_id', 'in', unitIds).execute()
+			await trx.deleteFrom(CourseUnitTable._table).where('id', 'in', unitIds).execute()
+		}
+
+		await trx.deleteFrom(CourseAssessmentTable._table).where('course_id', '=', courseId).execute()
+		await trx.deleteFrom(StudyPlanCourseTable._table).where('course_id', '=', courseId).execute()
+		await trx.deleteFrom(CourseTable._table).where('id', '=', courseId).execute()
+	})
+
+	await redis.publish(
+		`course:updated:${courseId}`,
+		JSON.stringify({ status: 'deleted', courseId, updatedAt: new Date().toISOString() })
+	)
+
+	await flushResponseCaches()
+
+	LoggerJobContext.add({ deleted_course_id: courseId })
 }
 
 /**

--- a/docs/api/JOBS.md
+++ b/docs/api/JOBS.md
@@ -28,6 +28,25 @@ The API consumes results from the scraper via `ScraperResponseQueue`. Each incom
 **File:** `src/Jobs/ScraperResponseInSISCourseJob.ts`
 
 Syncs a fully scraped `ScraperInSISCourse` into MySQL and notifies waiting SSE clients via Redis.
+When the scraper signals that a course no longer exists (`course: null, course_id: <id>`), the job
+deletes the ghost course and all its child rows instead of upserting.
+
+### Not-Found / Ghost Course Deletion
+
+When `data.course === null` and `data.course_id` is present, the job calls `deleteCourse(courseId)`:
+
+```
+1. SELECT id from insis_courses WHERE id = courseId — no-op if not found
+2. Transaction:
+   a. SELECT unit ids from insis_courses_units WHERE course_id = ?
+   b. DELETE insis_courses_units_slots WHERE unit_id IN (...)
+   c. DELETE insis_courses_units WHERE id IN (...)
+   d. DELETE insis_courses_assessments WHERE course_id = ?
+   e. DELETE insis_study_plans_courses WHERE course_id = ?
+   f. DELETE insis_courses WHERE id = ?
+3. redis.publish('course:updated:{id}', { status: 'deleted', ... })
+4. flushResponseCaches()
+```
 
 ### Change Detection
 

--- a/docs/scraper/JOBS.md
+++ b/docs/scraper/JOBS.md
@@ -109,7 +109,13 @@ content, assessment methods, timetable, and study plan references.
 2. GET url + lang=cz param via InSISHTTPClientService
    └─ on failure: throw InSISNetworkError (retried up to 3×)
 
-3. ExtractInSISCourseService.extract(html, url)
+3. ExtractInSISCourseService.isNotFound(html)
+   If InSIS returns a "course does not exist" error page (detected by the Czech string
+   "neexistuje nebo jeho sylabus není veřejně přístupný"), the job calls
+   QueueService.addCourseNotFound(courseId) instead of extracting, then returns null.
+   The API job will delete the ghost course on receiving this signal.
+
+4. ExtractInSISCourseService.extract(html, url)
    Internally:
    ├─ sanitizeBodyHtml (normalize &nbsp;)
    ├─ resolveId (from <input name="predmet"> or URL)
@@ -125,13 +131,14 @@ content, assessment methods, timetable, and study plan references.
    ├─ extractStudyLoad (activity + hours table)
    └─ extractAuditInfo (last_modified_by + last_modified_date from body text)
 
-4. QueueService.addCourseResponse(course)
-   → sends ScraperInSISCourse via InSIS:Course response job
+5. QueueService.addCourseResponse(course)
+   → sends ScraperInSISCourse + course_id via InSIS:Course response job
 
-5. return course
+6. return course
 ```
 
-**Output:** One `InSIS:Course` response job containing the full `ScraperInSISCourse` object.
+**Output:** One `InSIS:Course` response job containing the full `ScraperInSISCourse` object, or a
+`course: null` deletion signal when InSIS reports the course does not exist.
 
 **Error handling:**
 

--- a/scraper/src/Jobs/ScraperRequestInSISCourseJob.ts
+++ b/scraper/src/Jobs/ScraperRequestInSISCourseJob.ts
@@ -40,6 +40,14 @@ export default async function ScraperRequestInSISCourseJob(data: ScraperInSISCou
     }
     LoggerJobContext.add({ hash_miss: true, course_id: courseId })
 
+    if (ExtractInSISCourseService.isNotFound(result.data)) {
+        LoggerJobContext.add({ not_found: true, course_id: courseId })
+        if (courseId !== null) {
+            await QueueService.addCourseNotFound(courseId)
+        }
+        return null
+    }
+
     try {
         const course = ExtractInSISCourseService.extract(result.data, data.url)
 

--- a/scraper/src/Services/ExtractInSISCourseService.ts
+++ b/scraper/src/Services/ExtractInSISCourseService.ts
@@ -38,6 +38,14 @@ export default class ExtractInSISCourseService {
     }
 
     /**
+     * Returns true when InSIS reports that the course does not exist
+     * or its syllabus is not publicly accessible.
+     */
+    static isNotFound(html: string): boolean {
+        return html.includes('neexistuje nebo jeho sylabus není veřejně přístupný')
+    }
+
+    /**
      * Main extraction method - parses complete course data from syllabus page.
      */
     static extract(html: string, url: string): ScraperInSISCourse {

--- a/scraper/src/Services/QueueService.ts
+++ b/scraper/src/Services/QueueService.ts
@@ -25,7 +25,16 @@ export class QueueService {
     static async addCourseResponse(course: ScraperInSISCourse): Promise<void> {
         await scraper.queue.response.add('InSIS Course Response', {
             type: 'InSIS:Course',
+            course_id: course.id,
             course
+        })
+    }
+
+    static async addCourseNotFound(courseId: number): Promise<void> {
+        await scraper.queue.response.add('InSIS Course Response', {
+            type: 'InSIS:Course',
+            course_id: courseId,
+            course: null
         })
     }
 

--- a/scraper/src/Tests/ExtractInSISCourseService.test.ts
+++ b/scraper/src/Tests/ExtractInSISCourseService.test.ts
@@ -47,4 +47,15 @@ describe('ExtractInSISCourseService', () => {
             expect(ExtractInSISCourseService.extractIdFromHtml('<html><body></body></html>')).toBeNull()
         })
     })
+
+    describe('isNotFound', () => {
+        it('returns true for InSIS not-found error page fixture', () => {
+            const html = load('not-found.html')
+            expect(ExtractInSISCourseService.isNotFound(html)).toBe(true)
+        })
+
+        it('returns false for normal course page', () => {
+            expect(ExtractInSISCourseService.isNotFound('<html><body>Kód předmětu: 4IT123</body></html>')).toBe(false)
+        })
+    })
 })

--- a/scraper/src/Tests/fixtures/courses/not-found.html
+++ b/scraper/src/Tests/fixtures/courses/not-found.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Zvolený předmět neexistuje nebo jeho sylabus není veřejně přístupný.</p>
+</body>
+</html>

--- a/scraper/src/Tests/fixtures/courses/not-found.html
+++ b/scraper/src/Tests/fixtures/courses/not-found.html
@@ -1,6 +1,252 @@
-<!DOCTYPE html>
 <html>
-<body>
-<p>Zvolený předmět neexistuje nebo jeho sylabus není veřejně přístupný.</p>
-</body>
+    <head>
+        <title>Univerzitní informační systém</title>
+        <meta http-equiv="Content-Language" content="cs" />
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="description" content="Univerzitní informační systém VŠE" />
+        <meta name="lang" content="cs" />
+        <meta name="charset" content="UTF-8" />
+        <link rel="icon" href="/favicon/fav-prod.ico" sizes="32x32" />
+        <link rel="icon" href="/favicon/fav-prod.svg" type="image/svg+xml" />
+        <script type="text/javascript">
+            var defaultClass = ''
+        </script>
+        <link rel="stylesheet" type="text/css" href="/css/base.css?1777900356" />
+        <link rel="stylesheet" type="text/css" href="/css/local.css?1673252855" />
+        <link rel="stylesheet" type="text/css" href="/img.pl?css=34171" />
+        <link rel="stylesheet" type="text/css" href="/js/jquery/ui/ui-1.12.1/jquery-ui.min.css?1510843879" />
+        <script type="text/javascript" src="/js/jquery/jquery/jquery-3.3.1/jquery-3.3.1.min.js"></script>
+        <link type="text/css" rel="stylesheet" id="dark-mode-custom-link" />
+        <link type="text/css" rel="stylesheet" id="dark-mode-general-link" />
+        <style lang="en" type="text/css" id="dark-mode-custom-style"></style>
+        <style lang="en" type="text/css" id="dark-mode-native-style"></style>
+        <style lang="en" type="text/css" id="dark-mode-native-sheet"></style>
+        <script type="text/javascript" src="/js/common.js?1515155616"></script>
+        <script type="text/javascript" src="/js/uisplugins/uis.js?1727865117"></script>
+        <script type="text/javascript" src="/js/translate.js?1777892588"></script>
+        <script type="text/javascript" src="/js/icons.js?1758189455"></script>
+        <script type="text/javascript" src="/js/js.cookie.min.js"></script>
+        <script type="text/javascript">
+            uis.translator.setLang('CZ')
+        </script>
+        <script type="text/javascript" src="/js/pseudostrap.js?1780052805"></script>
+        <script type="text/javascript">
+            uis.params.transport.add('lang', 'cz')
+        </script>
+        <script type="text/javascript" src="/js/jquery/ui/ui-1.12.1/jquery-ui.min.js?1473867246"></script>
+        <script type="text/javascript" src="/js/jquery/ui/corrector.js?1638201715"></script>
+        <script type="text/javascript" src="/js/help.js?1758176588"></script>
+    </head>
+    <body>
+        <div id="base">
+            <div id="head">
+                <!-- head zacatek -->
+                <div id="uis-nazev">
+                    <h1>Integrovaný studijní informační systém</h1>
+                    <img class="in-header" src="/img.pl?userunid=8615" title="Dnes je" />
+                    18. 6. 2026&nbsp; 14:44 &nbsp;&nbsp;&nbsp;
+                    <img class="in-header" src="/img.pl?userunid=8616" title="Svátek má" />
+                    Milan
+                </div>
+                <div id="univerzita">
+                    <a href="http://www.vse.cz"><span></span></a>
+                </div>
+
+                <div id="shead">
+                    <!-- prava -->
+
+                    <div id="vlajky">
+                        &nbsp;
+                        <a href="https://insis.vse.cz/katalog/syllabus.pl?predmet=217914;lang=en" title="">ENGLISH</a>&nbsp; &nbsp;
+
+                        <a href="https://insis.vse.cz/katalog/syllabus.pl?predmet=217914;lang=sk" title="">SLOVENSKY</a>&nbsp;
+                    </div>
+                </div>
+                <!-- shead -->
+                <div id="spomoc2">
+                    <div id="ikonky"></div>
+                </div>
+                <!-- -- konec spomoc2 ---->
+            </div>
+            <!-- end head -->
+            <!-- zacatek stranky -->
+
+            <div id="navigace">
+                <span id="ikonecky"> </span>
+
+                <span id="logs"> <strong> </strong>&nbsp; </span>
+
+                <ul>
+                    <li></li>
+                    <li></li>
+                    <li></li>
+                    <ul></ul>
+                </ul>
+            </div>
+
+            <blockquote id="str">
+                <div class="mainpage">
+                    <div id="str1">
+                        <div>
+                            <div>
+                                <div>
+                                    <div>
+                                        <div>
+                                            <div>
+                                                <div>
+                                                    <div>
+                                                        <div>
+                                                            <div>
+                                                                <div>
+                                                                    <nav aria-label="breadcrumb">
+                                                                        <ol class="breadcrumb">
+                                                                            <li class="breadcrumb-item">
+                                                                                <a href="https://insis.vse.cz/" title="">Osobní administrativa</a>
+                                                                            </li>
+                                                                            <li class="breadcrumb-item"><a href="./" title="">Katalog předmětů</a></li>
+                                                                            <li class="breadcrumb-item active" aria-current="page">
+                                                                                <span>Univerzitní informační systém</span>
+                                                                            </li>
+                                                                        </ol>
+                                                                        <div class="helpinbreadcrumbs">
+                                                                            <a
+                                                                                href="/help.pl?page=9044"
+                                                                                class="context-help-invoke"
+                                                                                target="_blank"
+                                                                                title="Zobrazit nápovědu k&nbsp;aplikaci"
+                                                                                data-contexthelppage="9044"
+                                                                                ><span
+                                                                                    class="uf-icon xs"
+                                                                                    role="img"
+                                                                                    data-sysid="base-help"
+                                                                                    data-id="1035"
+                                                                                    aria-label=""
+                                                                                    alt=""
+                                                                                >
+                                                                                    <svg
+                                                                                        style="
+                                                                                            --uc-fill-inner: #ffffff;
+                                                                                            --_left: 0px;
+                                                                                            --_top: 0px;
+                                                                                            --_width: 48px;
+                                                                                            --_height: 48px;
+                                                                                            z-index: 20;
+                                                                                        "
+                                                                                        data-size-sysid="fullsize"
+                                                                                        aria-hidden="true"
+                                                                                        role="img"
+                                                                                    >
+                                                                                        <use
+                                                                                            xlink:href="/icons.svg?1772024892#uc-glyph1218"
+                                                                                            href="/icons.svg?1772024892#uc-glyph1218"
+                                                                                        ></use></svg
+                                                                                    ><svg
+                                                                                        style="
+                                                                                            --uc-fill-inner: #231f20;
+                                                                                            --_left: 0px;
+                                                                                            --_top: 0px;
+                                                                                            --_width: 48px;
+                                                                                            --_height: 48px;
+                                                                                            z-index: 5;
+                                                                                        "
+                                                                                        data-size-sysid="fullsize"
+                                                                                        aria-hidden="true"
+                                                                                        role="img"
+                                                                                    >
+                                                                                        <use
+                                                                                            xlink:href="/icons.svg?1772024892#uc-glyph1021"
+                                                                                            href="/icons.svg?1772024892#uc-glyph1021"
+                                                                                        ></use>
+                                                                                    </svg> </span
+                                                                            ></a>
+                                                                        </div>
+                                                                    </nav>
+                                                                    <div class="uis_msg ko" id="">
+                                                                        <span
+                                                                            class="uf-icon xs"
+                                                                            role="img"
+                                                                            data-sysid="vypis-ko"
+                                                                            data-id="4638"
+                                                                            aria-label=""
+                                                                            alt=""
+                                                                            title=""
+                                                                        >
+                                                                            <svg
+                                                                                style="
+                                                                                    --uc-fill-inner: #ff0000;
+                                                                                    --_left: 0px;
+                                                                                    --_top: 0px;
+                                                                                    --_width: 48px;
+                                                                                    --_height: 48px;
+                                                                                    z-index: 5;
+                                                                                "
+                                                                                data-size-sysid="fullsize"
+                                                                                aria-hidden="true"
+                                                                                role="img"
+                                                                            >
+                                                                                <use
+                                                                                    xlink:href="/icons.svg?1772024892#uc-glyph1021"
+                                                                                    href="/icons.svg?1772024892#uc-glyph1021"
+                                                                                ></use></svg
+                                                                            ><svg
+                                                                                style="
+                                                                                    --uc-fill-inner: #ffffff;
+                                                                                    --_left: 0px;
+                                                                                    --_top: 0px;
+                                                                                    --_width: 48px;
+                                                                                    --_height: 48px;
+                                                                                    z-index: 20;
+                                                                                "
+                                                                                data-size-sysid="fullsize"
+                                                                                aria-hidden="true"
+                                                                                role="img"
+                                                                            >
+                                                                                <use
+                                                                                    xlink:href="/icons.svg?1772024892#uc-glyph359"
+                                                                                    href="/icons.svg?1772024892#uc-glyph359"
+                                                                                ></use>
+                                                                            </svg>
+                                                                        </span>
+                                                                        <div>
+                                                                            <div class="text">
+                                                                                Zvolený předmět neexistuje nebo jeho sylabus není veřejně přístupný.
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                    <div class="pseudostrap-activated"></div>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </blockquote>
+        </div>
+        <!-- konec base -->
+        <script async="" src="//www.googletagmanager.com/gtag/js?id=G-1H88NNDR00"></script>
+        <script>
+            window.dataLayer = window.dataLayer || []
+            function gtag() {
+                dataLayer.push(arguments)
+            }
+            gtag('js', new Date())
+            gtag('consent', 'default', { ad_storage: 'denied', analytics_storage: 'denied' })
+            gtag('config', 'G-1H88NNDR00', { language: 'cs-CZ', transaction_id: '2298331109' })
+        </script>
+        <div
+            id="uis-control-data"
+            data-nove_ikonky="1"
+            data-uis_ang_lokalizace="GB"
+            data-stat_tel_predvolba="+420"
+            data-cookie_cooperation=""
+            data-module_cookiebar="0"
+        ></div>
+    </body>
 </html>

--- a/shared/queue/jobs.ts
+++ b/shared/queue/jobs.ts
@@ -89,6 +89,7 @@ export interface ScraperInSISCatalogResponseJob extends ScraperResponseJobBase {
 
 export interface ScraperInSISCourseResponseJob extends ScraperResponseJobBase {
     type: 'InSIS:Course'
+    course_id: number
     course: ScraperInSISCourse | null
 }
 


### PR DESCRIPTION
## Summary

- Scraper detects the InSIS "course does not exist" page via `ExtractInSISCourseService.isNotFound()`
- Enqueues a deletion signal (`course: null`, `course_id: number`) to the API response queue
- API job deletes slots → units → assessments → study_plan_courses → course in a transaction, then publishes `course:updated:{id}` with `status: 'deleted'` and flushes caches
- `ScraperInSISCourseResponseJob` now carries `course_id: number` as a top-level field so the API knows which course to remove when `course` is null
- Added HTML fixture + `isNotFound` test in scraper test suite

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)