### PR TITLE
fix(client): sequential 1–5 wizard step numbering

### DIFF
--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -222,8 +222,8 @@
 			"step1": "Vyberte svou fakultu",
 			"step2": "Zvolte rok nástupu ke studiu",
 			"step3": "Vyberte svůj studijní plán",
-			"step3b": "Označte kurzy, které jste již absolvovali (volitelné)",
-			"step4": "Procházejte předměty a sestavte si rozvrh",
+			"step4": "Označte kurzy, které jste již absolvovali (volitelné)",
+			"step5": "Procházejte předměty a sestavte si rozvrh",
 			"footer": "Kreditožrouti · Data z",
 			"insisLink": "InSIS VŠE"
 		},

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -222,8 +222,8 @@
 			"step1": "Select your faculty",
 			"step2": "Choose your enrollment year",
 			"step3": "Select your study plan",
-			"step3b": "Mark courses you've already completed (optional)",
-			"step4": "Browse courses and build your schedule",
+			"step4": "Mark courses you've already completed (optional)",
+			"step5": "Browse courses and build your schedule",
 			"footer": "Kreditožrouti · Data from",
 			"insisLink": "InSIS VŠE"
 		},

--- a/client/src/pages/index.vue
+++ b/client/src/pages/index.vue
@@ -61,8 +61,8 @@ onMounted(() => {
 						<li><strong>1.</strong> {{ $t('pages.index.step1') }}</li>
 						<li><strong>2.</strong> {{ $t('pages.index.step2') }}</li>
 						<li><strong>3.</strong> {{ $t('pages.index.step3') }}</li>
-						<li><strong>3b.</strong> {{ $t('pages.index.step3b') }}</li>
 						<li><strong>4.</strong> {{ $t('pages.index.step4') }}</li>
+						<li><strong>5.</strong> {{ $t('pages.index.step5') }}</li>
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary

- Renames i18n keys `step3b` → `step4` and old `step4` → `step5` in both `cs.json` and `en.json`
- Updates `index.vue` to render `3.`, `4.`, `5.` instead of `3.`, `3b.`, `4.`

## Test plan
- [ ] Wizard "How does it work?" list shows steps 1–5 with no `3b`
- [ ] Czech and English locales both render correctly

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)