### PR TITLE
feat(client): unify i18n routing — locale-prefixed /legal/:locale/:slug URLs

### DIFF
--- a/client/src/components/common/AppFooter.vue
+++ b/client/src/components/common/AppFooter.vue
@@ -1,5 +1,4 @@
 ﻿<script setup lang="ts">
-import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { RouterLink } from 'vue-router'
 import IconExternalLink from '~icons/lucide/external-link'
@@ -10,13 +9,10 @@ import IconBookOpen from '~icons/lucide/book-open'
 import IconInfo from '~icons/lucide/info'
 import IconMail from '~icons/lucide/mail'
 
-const { t, locale } = useI18n()
+const { t } = useI18n()
 
 const currentYear = new Date().getFullYear()
 const appVersion = APP_VERSION
-
-const aboutPath = computed(() => (locale.value === 'cs' ? '/about/cs' : '/about/en'))
-const compliancePath = computed(() => `/legal/${locale.value}/compliance`)
 </script>
 
 <template>
@@ -54,7 +50,7 @@ const compliancePath = computed(() => `/legal/${locale.value}/compliance`)
 						</li>
 						<li>
 							<RouterLink
-								:to="aboutPath"
+								to="/about"
 								class="flex items-center gap-2 text-left text-(--insis-gray-700) transition-colors hover:text-(--insis-blue)"
 							>
 								<IconInfo class="h-4 w-4 shrink-0" aria-hidden="true" />
@@ -63,7 +59,7 @@ const compliancePath = computed(() => `/legal/${locale.value}/compliance`)
 						</li>
 						<li>
 							<RouterLink
-								:to="compliancePath"
+								to="/legal/compliance"
 								class="flex items-center gap-2 text-left text-(--insis-gray-700) transition-colors hover:text-(--insis-blue)"
 							>
 								<IconFileText class="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/client/src/components/common/AppFooter.vue
+++ b/client/src/components/common/AppFooter.vue
@@ -16,6 +16,7 @@ const currentYear = new Date().getFullYear()
 const appVersion = APP_VERSION
 
 const aboutPath = computed(() => (locale.value === 'cs' ? '/about/cs' : '/about/en'))
+const compliancePath = computed(() => `/legal/${locale.value}/compliance`)
 </script>
 
 <template>
@@ -62,7 +63,7 @@ const aboutPath = computed(() => (locale.value === 'cs' ? '/about/cs' : '/about/
 						</li>
 						<li>
 							<RouterLink
-								to="/legal/compliance"
+								:to="compliancePath"
 								class="flex items-center gap-2 text-left text-(--insis-gray-700) transition-colors hover:text-(--insis-blue)"
 							>
 								<IconFileText class="h-4 w-4 shrink-0" aria-hidden="true" />

--- a/client/src/pages/legal/[locale]/[slug].vue
+++ b/client/src/pages/legal/[locale]/[slug].vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
+import { useHead, useSeoMeta } from '@unhead/vue'
+import { marked } from 'marked'
+import AppHeader from '@client/components/common/AppHeader.vue'
+import LegalSidebar from '@client/components/legal/LegalSidebar.vue'
+import { i18n } from '@client/i18n'
+
+const route = useRoute('/legal/[locale]/[slug]')
+const router = useRouter()
+
+const SUPPORTED_LOCALES = ['cs', 'en'] as const
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+const allDocs = import.meta.glob('../../../legal/**/*.md', {
+	query: '?raw',
+	import: 'default'
+}) as Record<string, () => Promise<string>>
+
+marked.use({
+	renderer: {
+		heading(token) {
+			const id = token.text
+				.toLowerCase()
+				.replace(/[^\w\s-]/g, '')
+				.replace(/\s+/g, '-')
+			return `<h${token.depth} id="${id}">${token.text}</h${token.depth}>\n`
+		}
+	}
+})
+
+const renderedHtml = ref('')
+const loading = ref(true)
+const notFound = ref(false)
+
+async function loadDoc() {
+	loading.value = true
+	notFound.value = false
+	renderedHtml.value = ''
+
+	const locale = route.params.locale as string
+	const slug = route.params.slug as string
+
+	if (!SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
+		notFound.value = true
+		loading.value = false
+		return
+	}
+
+	const localeKey = `../../../legal/${locale}/${slug}.md`
+	const fallbackKey = `../../../legal/en/${slug}.md`
+	const loader = allDocs[localeKey] ?? allDocs[fallbackKey]
+
+	if (!loader) {
+		notFound.value = true
+		loading.value = false
+		return
+	}
+
+	try {
+		const raw = await loader()
+		renderedHtml.value = await marked(raw)
+	} catch {
+		notFound.value = true
+	} finally {
+		loading.value = false
+	}
+}
+
+watch([() => route.params.locale, () => route.params.slug], loadDoc, { immediate: true })
+
+watch(
+	() => i18n.global.locale.value,
+	newLocale => {
+		const slug = route.params.slug as string
+		router.push(`/legal/${newLocale}/${slug}`)
+	}
+)
+
+useSeoMeta({
+	robots: 'index, follow'
+})
+
+useHead({
+	link: [
+		{
+			rel: 'alternate',
+			hreflang: 'cs',
+			href: () => `https://kreditozrouti.cz/legal/cs/${route.params.slug}`
+		},
+		{
+			rel: 'alternate',
+			hreflang: 'en',
+			href: () => `https://kreditozrouti.cz/legal/en/${route.params.slug}`
+		},
+		{
+			rel: 'alternate',
+			hreflang: 'x-default',
+			href: () => `https://kreditozrouti.cz/legal/cs/${route.params.slug}`
+		},
+		{
+			rel: 'canonical',
+			href: () => `https://kreditozrouti.cz/legal/${route.params.locale}/${route.params.slug}`
+		}
+	]
+})
+</script>
+
+<template>
+	<div class="flex min-h-screen flex-col bg-(--insis-bg)">
+		<AppHeader />
+		<main class="mx-auto w-full max-w-6xl flex-1 px-4 py-12 sm:px-6 lg:px-8">
+			<div v-if="loading" class="animate-pulse space-y-4 pt-2">
+				<div class="h-8 w-1/2 rounded-lg bg-(--insis-gray-200)" />
+				<div class="h-4 w-full rounded bg-(--insis-gray-200)" />
+				<div class="h-4 w-5/6 rounded bg-(--insis-gray-200)" />
+				<div class="h-4 w-4/6 rounded bg-(--insis-gray-200)" />
+				<div class="mt-6 h-5 w-1/3 rounded-lg bg-(--insis-gray-200)" />
+				<div class="h-4 w-full rounded bg-(--insis-gray-200)" />
+				<div class="h-4 w-3/4 rounded bg-(--insis-gray-200)" />
+			</div>
+
+			<div v-else-if="notFound" class="py-20 text-center">
+				<h1 class="text-2xl font-bold text-(--insis-gray-800)">Document not found</h1>
+				<p class="mt-2 text-(--insis-gray-600)">The requested document does not exist.</p>
+				<RouterLink to="/" class="mt-6 inline-block text-sm text-(--insis-blue) hover:underline">← Back to home</RouterLink>
+			</div>
+
+			<div v-else class="flex gap-10">
+				<LegalSidebar :html="renderedHtml" class="hidden lg:block" />
+				<article class="prose max-w-none min-w-0 flex-1" v-html="renderedHtml" />
+			</div>
+		</main>
+	</div>
+</template>

--- a/client/src/pages/legal/[slug].vue
+++ b/client/src/pages/legal/[slug].vue
@@ -1,88 +1,20 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { RouterLink, useRoute } from 'vue-router'
-import { marked } from 'marked'
-import AppHeader from '@client/components/common/AppHeader.vue'
-import LegalSidebar from '@client/components/legal/LegalSidebar.vue'
+import { watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { i18n } from '@client/i18n'
 
 const route = useRoute('/legal/[slug]')
-const { locale } = useI18n()
+const router = useRouter()
 
-const allDocs = import.meta.glob('../../legal/**/*.md', {
-	query: '?raw',
-	import: 'default'
-}) as Record<string, () => Promise<string>>
-
-marked.use({
-	renderer: {
-		heading(token) {
-			const id = token.text
-				.toLowerCase()
-				.replace(/[^\w\s-]/g, '')
-				.replace(/\s+/g, '-')
-			return `<h${token.depth} id="${id}">${token.text}</h${token.depth}>\n`
-		}
-	}
-})
-
-const renderedHtml = ref('')
-const loading = ref(true)
-const notFound = ref(false)
-
-async function loadDoc() {
-	loading.value = true
-	notFound.value = false
-	renderedHtml.value = ''
-
-	const slug = route.params.slug as string
-	const localeKey = `../../legal/${locale.value}/${slug}.md`
-	const fallbackKey = `../../legal/en/${slug}.md`
-	const loader = allDocs[localeKey] ?? allDocs[fallbackKey]
-
-	if (!loader) {
-		notFound.value = true
-		loading.value = false
-		return
-	}
-
-	try {
-		const raw = await loader()
-		renderedHtml.value = await marked(raw)
-	} catch {
-		notFound.value = true
-	} finally {
-		loading.value = false
-	}
-}
-
-watch([() => route.params.slug, locale], loadDoc, { immediate: true })
+watch(
+	() => route.params.slug,
+	slug => {
+		router.replace(`/legal/${i18n.global.locale.value}/${slug}`)
+	},
+	{ immediate: true }
+)
 </script>
 
 <template>
-	<div class="flex min-h-screen flex-col bg-(--insis-bg)">
-		<AppHeader />
-		<main class="mx-auto w-full max-w-6xl flex-1 px-4 py-12 sm:px-6 lg:px-8">
-			<div v-if="loading" class="animate-pulse space-y-4 pt-2">
-				<div class="h-8 w-1/2 rounded-lg bg-(--insis-gray-200)" />
-				<div class="h-4 w-full rounded bg-(--insis-gray-200)" />
-				<div class="h-4 w-5/6 rounded bg-(--insis-gray-200)" />
-				<div class="h-4 w-4/6 rounded bg-(--insis-gray-200)" />
-				<div class="mt-6 h-5 w-1/3 rounded-lg bg-(--insis-gray-200)" />
-				<div class="h-4 w-full rounded bg-(--insis-gray-200)" />
-				<div class="h-4 w-3/4 rounded bg-(--insis-gray-200)" />
-			</div>
-
-			<div v-else-if="notFound" class="py-20 text-center">
-				<h1 class="text-2xl font-bold text-(--insis-gray-800)">Document not found</h1>
-				<p class="mt-2 text-(--insis-gray-600)">The requested document does not exist.</p>
-				<RouterLink to="/" class="mt-6 inline-block text-sm text-(--insis-blue) hover:underline">← Back to home</RouterLink>
-			</div>
-
-			<div v-else class="flex gap-10">
-				<LegalSidebar :html="renderedHtml" class="hidden lg:block" />
-				<article class="prose max-w-none min-w-0 flex-1" v-html="renderedHtml" />
-			</div>
-		</main>
-	</div>
+	<div />
 </template>

--- a/client/src/route-map.d.ts
+++ b/client/src/route-map.d.ts
@@ -87,6 +87,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/legal/[locale]/[slug]': RouteRecordInfo<
+      '/legal/[locale]/[slug]',
+      '/legal/:locale/:slug',
+      { locale: ParamValue<true>, slug: ParamValue<true> },
+      { locale: ParamValue<false>, slug: ParamValue<false> },
+      | never
+    >,
     '/legal/[slug]': RouteRecordInfo<
       '/legal/[slug]',
       '/legal/:slug',
@@ -170,6 +177,14 @@ declare module 'vue-router/auto-routes' {
         | never
       pathParamNames:
         | never
+    }
+    'src/pages/legal/[locale]/[slug].vue': {
+      routes:
+        | '/legal/[locale]/[slug]'
+      views:
+        | never
+      pathParamNames:
+        | 'slug'
     }
     'src/pages/legal/[slug].vue': {
       routes:


### PR DESCRIPTION
Closes #124

## Summary

- **New locale-prefixed legal pages** at `/legal/cs/<slug>` and `/legal/en/<slug>` — each emits correct `hreflang` alternate links and a `canonical` tag
- **Redirect** — bare `/legal/<slug>` URLs (existing bookmarks) redirect to the current-locale variant so no links break
- **AppFooter** — compliance link updated to use locale-aware path (`/legal/<locale>/compliance`) to skip the redirect hop

## How it works

`pages/legal/[locale]/[slug].vue` follows the same pattern as `guide/cs.vue` and `guide/en.vue`: the locale is encoded in the URL, `useHead` emits hreflang + canonical, and a watcher redirects when the user switches language.

`pages/legal/[slug].vue` is converted to a thin redirect (mirrors `guide/index.vue` / `about/index.vue` pattern).

## Test plan

- [ ] `/legal/cs/compliance` loads Czech markdown
- [ ] `/legal/en/compliance` loads English markdown
- [ ] Switching locale on `/legal/cs/compliance` navigates to `/legal/en/compliance` (and vice versa)
- [ ] `/legal/compliance` redirects to `/legal/<current-locale>/compliance`
- [ ] `<link rel="alternate" hreflang="cs|en">` tags present in page `<head>`
- [ ] Footer compliance link goes directly to locale URL (no redirect hop)
- [ ] Timetable / courses page unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)