### PR TITLE
refactor(client): replace inline SVG icons with Lucide (#135)

### DIFF
--- a/client/src/components/timetable/TimetableAgenda.vue
+++ b/client/src/components/timetable/TimetableAgenda.vue
@@ -8,6 +8,9 @@ import { useI18n } from 'vue-i18n'
 import TimetableCourseModal from '@client/components/timetable/TimetableCourseModal.vue'
 import { WEEKDAYS } from '@client/constants/timetable'
 import { useAlertsStore, useTimetableStore } from '@client/stores'
+import IconDownload from '~icons/lucide/download'
+import IconLoaderCircle from '~icons/lucide/loader-circle'
+import IconShare2 from '~icons/lucide/share-2'
 import IconX from '~icons/lucide/x'
 
 const props = withDefaults(
@@ -144,8 +147,8 @@ function removeFromTimetable(unit: SelectedCourseUnit | MergedUnit) {
 				class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 				@click="handleShare"
 			>
-				<i-lucide-share-2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
-				<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+				<IconShare2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
+				<IconLoaderCircle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 				{{ sharing ? $t('components.timetable.TimetableGrid.sharing') : $t('components.timetable.TimetableGrid.share') }}
 			</button>
 			<!-- Export button -->
@@ -156,8 +159,8 @@ function removeFromTimetable(unit: SelectedCourseUnit | MergedUnit) {
 				class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 				@click="exportSchedule"
 			>
-				<i-lucide-download v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
-				<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+				<IconDownload v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
+				<IconLoaderCircle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 				{{ exporting ? $t('components.timetable.TimetableAgenda.exporting') : $t('components.timetable.TimetableAgenda.saveAsImage') }}
 			</button>
 		</div>

--- a/client/src/components/timetable/TimetableAgenda.vue
+++ b/client/src/components/timetable/TimetableAgenda.vue
@@ -144,36 +144,8 @@ function removeFromTimetable(unit: SelectedCourseUnit | MergedUnit) {
 				class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 				@click="handleShare"
 			>
-				<svg
-					v-if="!sharing"
-					xmlns="http://www.w3.org/2000/svg"
-					class="h-3.5 w-3.5"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					aria-hidden="true"
-				>
-					<circle cx="18" cy="5" r="3" />
-					<circle cx="6" cy="12" r="3" />
-					<circle cx="18" cy="19" r="3" />
-					<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-					<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-				</svg>
-				<svg
-					v-else
-					xmlns="http://www.w3.org/2000/svg"
-					class="h-3.5 w-3.5 animate-spin"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					aria-hidden="true"
-				>
-					<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-				</svg>
+				<i-lucide-share-2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
+				<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 				{{ sharing ? $t('components.timetable.TimetableGrid.sharing') : $t('components.timetable.TimetableGrid.share') }}
 			</button>
 			<!-- Export button -->
@@ -184,34 +156,8 @@ function removeFromTimetable(unit: SelectedCourseUnit | MergedUnit) {
 				class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 				@click="exportSchedule"
 			>
-				<svg
-					v-if="!exporting"
-					xmlns="http://www.w3.org/2000/svg"
-					class="h-3.5 w-3.5"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					aria-hidden="true"
-				>
-					<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-					<polyline points="7 10 12 15 17 10" />
-					<line x1="12" y1="15" x2="12" y2="3" />
-				</svg>
-				<svg
-					v-else
-					xmlns="http://www.w3.org/2000/svg"
-					class="h-3.5 w-3.5 animate-spin"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					aria-hidden="true"
-				>
-					<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-				</svg>
+				<i-lucide-download v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
+				<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 				{{ exporting ? $t('components.timetable.TimetableAgenda.exporting') : $t('components.timetable.TimetableAgenda.saveAsImage') }}
 			</button>
 		</div>

--- a/client/src/components/timetable/TimetableGrid.vue
+++ b/client/src/components/timetable/TimetableGrid.vue
@@ -165,36 +165,8 @@ function getDragSelectionStyleForDay(day: InSISDay) {
 					class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 					@click="handleShare"
 				>
-					<svg
-						v-if="!sharing"
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-3.5 w-3.5"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<circle cx="18" cy="5" r="3" />
-						<circle cx="6" cy="12" r="3" />
-						<circle cx="18" cy="19" r="3" />
-						<line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
-						<line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
-					</svg>
-					<svg
-						v-else
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-3.5 w-3.5 animate-spin"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						aria-hidden="true"
-					>
-						<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-					</svg>
+					<i-lucide-share-2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
+					<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 					{{ sharing ? $t('components.timetable.TimetableGrid.sharing') : $t('components.timetable.TimetableGrid.share') }}
 				</button>
 
@@ -206,34 +178,8 @@ function getDragSelectionStyleForDay(day: InSISDay) {
 					class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 					@click="exportSchedule"
 				>
-					<svg
-						v-if="!exporting"
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-3.5 w-3.5"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-						aria-hidden="true"
-					>
-						<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-						<polyline points="7 10 12 15 17 10" />
-						<line x1="12" y1="15" x2="12" y2="3" />
-					</svg>
-					<svg
-						v-else
-						xmlns="http://www.w3.org/2000/svg"
-						class="h-3.5 w-3.5 animate-spin"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						aria-hidden="true"
-					>
-						<path d="M21 12a9 9 0 1 1-6.219-8.56" />
-					</svg>
+					<i-lucide-download v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
+					<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 					{{ exporting ? 'Exportuji...' : 'Uložit jako obrázek' }}
 				</button>
 			</div>

--- a/client/src/components/timetable/TimetableGrid.vue
+++ b/client/src/components/timetable/TimetableGrid.vue
@@ -11,6 +11,9 @@ import TimetableCourseModal from '@client/components/timetable/TimetableCourseMo
 import TimetableDragPopover from '@client/components/timetable/TimetableDragPopover.vue'
 import { WEEKDAYS } from '@client/constants/timetable'
 import { useAlertsStore, useDragStore, useTimetableStore } from '@client/stores'
+import IconDownload from '~icons/lucide/download'
+import IconLoaderCircle from '~icons/lucide/loader-circle'
+import IconShare2 from '~icons/lucide/share-2'
 
 const props = withDefaults(
 	defineProps<{
@@ -165,8 +168,8 @@ function getDragSelectionStyleForDay(day: InSISDay) {
 					class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 					@click="handleShare"
 				>
-					<i-lucide-share-2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
-					<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+					<IconShare2 v-if="!sharing" class="h-3.5 w-3.5" aria-hidden="true" />
+					<IconLoaderCircle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 					{{ sharing ? $t('components.timetable.TimetableGrid.sharing') : $t('components.timetable.TimetableGrid.share') }}
 				</button>
 
@@ -178,8 +181,8 @@ function getDragSelectionStyleForDay(day: InSISDay) {
 					class="flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium text-(--insis-blue) ring-1 ring-(--insis-blue)/30 transition hover:bg-(--insis-blue)/8 disabled:cursor-not-allowed disabled:opacity-50"
 					@click="exportSchedule"
 				>
-					<i-lucide-download v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
-					<i-lucide-loader-circle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+					<IconDownload v-if="!exporting" class="h-3.5 w-3.5" aria-hidden="true" />
+					<IconLoaderCircle v-else class="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
 					{{ exporting ? 'Exportuji...' : 'Uložit jako obrázek' }}
 				</button>
 			</div>


### PR DESCRIPTION
## Summary

- Replaced 4 hand-written `<svg>` icons in `TimetableGrid.vue` and `TimetableAgenda.vue` with `<i-lucide-*>` components via the already-configured `unplugin-icons`
- Icons replaced: `share-2` (share), `download` (export), `loader-circle` (loading spinner with `animate-spin`)
- No other SVGs found in `client/src/` — confirmed with a full search before starting

## Test plan

- [ ] Share button shows share icon, switches to spinning loader during share
- [ ] Export button shows download icon, switches to spinning loader during export
- [ ] Same behaviour in both Grid and Agenda views
- [ ] No visual regressions in icon size or colour

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)