### PR TITLE
fix(traefik): prevent false-positive bans and startup 403s

### DIFF
--- a/deployment/monitoring/docker-compose.monitoring.yml
+++ b/deployment/monitoring/docker-compose.monitoring.yml
@@ -31,6 +31,8 @@ services:
   prometheus:
     image: prom/prometheus:latest
     restart: unless-stopped
+    group_add:
+      - "999"
 
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'

--- a/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-details.json
+++ b/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-details.json
@@ -1,0 +1,1549 @@
+{
+	"__inputs": [
+		{
+			"name": "DS_PROMETHEUS",
+			"label": "Prometheus",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "prometheus",
+			"pluginName": "Prometheus"
+		}
+	],
+	"__elements": [],
+	"__requires": [
+		{
+			"type": "panel",
+			"id": "bargauge",
+			"name": "Bar gauge",
+			"version": ""
+		},
+		{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "9.0.2"
+		},
+		{
+			"type": "panel",
+			"id": "graph",
+			"name": "Graph (old)",
+			"version": ""
+		},
+		{
+			"type": "datasource",
+			"id": "prometheus",
+			"name": "Prometheus",
+			"version": "1.0.0"
+		},
+		{
+			"type": "panel",
+			"id": "stat",
+			"name": "Stat",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "timeseries",
+			"name": "Time series",
+			"version": ""
+		}
+	],
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": {
+					"type": "datasource",
+					"uid": "grafana"
+				},
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"target": {
+					"limit": 100,
+					"matchAny": false,
+					"tags": [],
+					"type": "dashboard"
+				},
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"fiscalYearStartMonth": 0,
+	"graphTooltip": 0,
+	"id": null,
+	"iteration": 1659090580950,
+	"links": [],
+	"liveNow": false,
+	"panels": [
+		{
+			"collapsed": true,
+			"datasource": {
+				"type": "prometheus",
+				"uid": "IH0jqv6nz"
+			},
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 22,
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 11,
+						"w": 12,
+						"x": 0,
+						"y": 1
+					},
+					"hiddenSeries": false,
+					"id": 18,
+					"legend": {
+						"alignAsTable": false,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": false,
+						"show": false,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"links": [],
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "process_resident_memory_bytes{instance=\"$instance\"}",
+							"interval": "",
+							"intervalFactor": 1,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Process Mem Usage",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "decbytes",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 11,
+						"w": 12,
+						"x": 12,
+						"y": 1
+					},
+					"hiddenSeries": false,
+					"id": 20,
+					"legend": {
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"show": false,
+						"total": false,
+						"values": false
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "rate(process_cpu_seconds_total{instance=\"$instance\"}[$__interval])*100",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Process CPU Usage",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "percent",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green"
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "dateTimeAsIso"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 0,
+						"y": 12
+					},
+					"id": 16,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "none",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "9.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "(process_start_time_seconds{instance=\"$instance\"})*1000",
+							"instant": false,
+							"interval": "",
+							"intervalFactor": 1,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"title": "Up Since",
+					"transparent": true,
+					"type": "stat"
+				}
+			],
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "IH0jqv6nz"
+					},
+					"refId": "A"
+				}
+			],
+			"title": "System",
+			"type": "row"
+		},
+		{
+			"collapsed": true,
+			"datasource": {
+				"type": "prometheus",
+				"uid": "IH0jqv6nz"
+			},
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 1
+			},
+			"id": 28,
+			"panels": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green"
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 0,
+						"y": 2
+					},
+					"id": 32,
+					"options": {
+						"colorMode": "value",
+						"graphMode": "area",
+						"justifyMode": "auto",
+						"orientation": "auto",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "9.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "sum(cs_alerts)",
+							"interval": "",
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"title": "Alerts Count",
+					"type": "stat"
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "palette-classic"
+							},
+							"custom": {
+								"axisLabel": "",
+								"axisPlacement": "auto",
+								"barAlignment": 0,
+								"drawStyle": "line",
+								"fillOpacity": 0,
+								"gradientMode": "none",
+								"hideFrom": {
+									"legend": false,
+									"tooltip": false,
+									"viz": false
+								},
+								"lineInterpolation": "linear",
+								"lineWidth": 1,
+								"pointSize": 5,
+								"scaleDistribution": {
+									"type": "linear"
+								},
+								"showPoints": "auto",
+								"spanNulls": false,
+								"stacking": {
+									"group": "A",
+									"mode": "none"
+								},
+								"thresholdsStyle": {
+									"mode": "off"
+								}
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green"
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 2
+					},
+					"id": 30,
+					"options": {
+						"legend": {
+							"calcs": [],
+							"displayMode": "list",
+							"placement": "bottom"
+						},
+						"tooltip": {
+							"mode": "single",
+							"sort": "none"
+						}
+					},
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "cs_alerts{instance=\"$instance\"}",
+							"interval": "",
+							"legendFormat": "{{reason}}",
+							"refId": "A"
+						}
+					],
+					"title": "Alerts per Scenario",
+					"type": "timeseries"
+				}
+			],
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "IH0jqv6nz"
+					},
+					"refId": "A"
+				}
+			],
+			"title": "Alerts",
+			"type": "row"
+		},
+		{
+			"collapsed": true,
+			"datasource": {
+				"type": "prometheus",
+				"uid": "IH0jqv6nz"
+			},
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 2
+			},
+			"id": 24,
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 12,
+						"w": 24,
+						"x": 0,
+						"y": 3
+					},
+					"hiddenSeries": false,
+					"id": 2,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "sum(increase(cs_filesource_hits_total{instance=\"$instance\"}[$__interval])) by (source)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{source}}",
+							"refId": "A"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "sum(increase(cs_journalctlsource_hits_total{instance=\"$instance\"}[$__interval])) by (source)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "{{source}}",
+							"refId": "B"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "sum(increase(cs_cloudwatch_stream_hits_total{instance=\"$instance\"}[$__interval])) by (group, stream)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "{{group}} - {{stream}}",
+							"refId": "C"
+						},
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"exemplar": true,
+							"expr": "sum(increase(cs_syslogsource_hits_total{instance=\"$instance\"}[$__interval])) by (source)",
+							"hide": false,
+							"interval": "",
+							"legendFormat": "",
+							"refId": "D"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Acquisition",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 11,
+						"w": 12,
+						"x": 0,
+						"y": 15
+					},
+					"hiddenSeries": false,
+					"id": 4,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(increase(cs_parser_hits_ok_total{instance=\"$instance\"}[$__interval])) by (source)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{source}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Parsed lines",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 11,
+						"w": 12,
+						"x": 12,
+						"y": 15
+					},
+					"hiddenSeries": false,
+					"id": 6,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(increase(cs_parser_hits_ko_total{instance=\"$instance\"}[$__interval])) by (source)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{source}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Unparsed lines",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 12,
+						"w": 12,
+						"x": 0,
+						"y": 26
+					},
+					"id": 34,
+					"options": {
+						"displayMode": "gradient",
+						"minVizHeight": 10,
+						"minVizWidth": 0,
+						"orientation": "auto",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"showUnfilled": true
+					},
+					"pluginVersion": "9.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"editorMode": "code",
+							"exemplar": true,
+							"expr": "sum(rate(cs_parsing_time_seconds_bucket{instance=\"$instance\", type=\"$datasource_type\", source=\"$source\"}[$__rate_interval])) by (le)",
+							"format": "heatmap",
+							"legendFormat": "{{le}}",
+							"range": true,
+							"refId": "A"
+						}
+					],
+					"title": "Parsing time",
+					"type": "heatmap"
+				}
+			],
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "IH0jqv6nz"
+					},
+					"refId": "A"
+				}
+			],
+			"title": "Parsing",
+			"type": "row"
+		},
+		{
+			"collapsed": true,
+			"datasource": {
+				"type": "prometheus",
+				"uid": "IH0jqv6nz"
+			},
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 3
+			},
+			"id": 26,
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 24,
+						"x": 0,
+						"y": 4
+					},
+					"hiddenSeries": false,
+					"id": 8,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(cs_buckets{instance=\"$instance\"}) by (name)",
+							"interval": "",
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Bucket Timeline",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 9,
+						"w": 24,
+						"x": 0,
+						"y": 12
+					},
+					"hiddenSeries": false,
+					"id": 12,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(increase(cs_bucket_created_total{instance=\"$instance\"}[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Buckets creation",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 24,
+						"x": 0,
+						"y": 21
+					},
+					"hiddenSeries": false,
+					"id": 11,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(increase(cs_bucket_overflowed_total{instance=\"$instance\"}[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Buckets overflow",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 24,
+						"x": 0,
+						"y": 29
+					},
+					"hiddenSeries": false,
+					"id": 14,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "9.0.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"expr": "sum(increase(cs_bucket_underflowed_total{instance=\"$instance\"}[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeRegions": [],
+					"title": "Buckets underflow",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"mode": "time",
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						},
+						{
+							"format": "short",
+							"logBase": 1,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false
+					}
+				},
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "${DS_PROMETHEUS}"
+					},
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 12,
+						"w": 12,
+						"x": 0,
+						"y": 37
+					},
+					"id": 35,
+					"options": {
+						"displayMode": "gradient",
+						"minVizHeight": 10,
+						"minVizWidth": 0,
+						"orientation": "auto",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"showUnfilled": true
+					},
+					"pluginVersion": "9.0.2",
+					"targets": [
+						{
+							"datasource": {
+								"type": "prometheus",
+								"uid": "${DS_PROMETHEUS}"
+							},
+							"editorMode": "code",
+							"exemplar": true,
+							"expr": "sum(rate(cs_bucket_pour_seconds_bucket{instance=\"$instance\", type=\"$datasource_type\", source=\"$source\"}[$__rate_interval])) by (le)",
+							"format": "heatmap",
+							"legendFormat": "{{le}}",
+							"range": true,
+							"refId": "A"
+						}
+					],
+					"title": "Bucket pour time",
+					"type": "heatmap"
+				}
+			],
+			"targets": [
+				{
+					"datasource": {
+						"type": "prometheus",
+						"uid": "IH0jqv6nz"
+					},
+					"refId": "A"
+				}
+			],
+			"title": "Buckets",
+			"type": "row"
+		}
+	],
+	"refresh": false,
+	"schemaVersion": 36,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"current": {},
+				"datasource": {
+					"type": "prometheus",
+					"uid": "${DS_PROMETHEUS}"
+				},
+				"definition": "label_values(cs_info, instance)",
+				"hide": 0,
+				"includeAll": false,
+				"label": "instance",
+				"multi": false,
+				"name": "instance",
+				"options": [],
+				"query": {
+					"query": "label_values(cs_info, instance)",
+					"refId": "Prometheus-instance-Variable-Query"
+				},
+				"refresh": 1,
+				"regex": "",
+				"skipUrlSync": false,
+				"sort": 1,
+				"tagValuesQuery": "",
+				"tagsQuery": "",
+				"type": "query",
+				"useTags": false
+			},
+			{
+				"current": {},
+				"datasource": {
+					"type": "prometheus",
+					"uid": "${DS_PROMETHEUS}"
+				},
+				"definition": "label_values(cs_parsing_time_seconds_bucket{instance=\"$instance\"}, type)",
+				"hide": 0,
+				"includeAll": false,
+				"multi": false,
+				"name": "datasource_type",
+				"options": [],
+				"query": {
+					"query": "label_values(cs_parsing_time_seconds_bucket{instance=\"$instance\"}, type)",
+					"refId": "StandardVariableQuery"
+				},
+				"refresh": 1,
+				"regex": "",
+				"skipUrlSync": false,
+				"sort": 0,
+				"type": "query"
+			},
+			{
+				"current": {},
+				"datasource": {
+					"type": "prometheus",
+					"uid": "${DS_PROMETHEUS}"
+				},
+				"definition": "label_values(cs_parsing_time_seconds_bucket{instance=\"$instance\", type=\"$datasource_type\"}, source)",
+				"hide": 0,
+				"includeAll": false,
+				"multi": false,
+				"name": "source",
+				"options": [],
+				"query": {
+					"query": "label_values(cs_parsing_time_seconds_bucket{instance=\"$instance\", type=\"$datasource_type\"}, source)",
+					"refId": "StandardVariableQuery"
+				},
+				"refresh": 1,
+				"regex": "",
+				"skipUrlSync": false,
+				"sort": 0,
+				"type": "query"
+			}
+		]
+	},
+	"time": {
+		"from": "now-15m",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+	},
+	"timezone": "",
+	"title": "Crowdsec Details per instance",
+	"uid": "6L2GdB47z",
+	"version": 7,
+	"weekStart": ""
+}

--- a/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-insight.json
+++ b/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-insight.json
@@ -1,0 +1,822 @@
+{
+	"__inputs": [
+		{
+			"name": "DS_PROMETHEUS",
+			"label": "Prometheus",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "prometheus",
+			"pluginName": "Prometheus"
+		}
+	],
+	"__requires": [
+		{
+			"type": "panel",
+			"id": "bargauge",
+			"name": "Bar gauge",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "gauge",
+			"name": "Gauge",
+			"version": ""
+		},
+		{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "8.1.2"
+		},
+		{
+			"type": "datasource",
+			"id": "prometheus",
+			"name": "Prometheus",
+			"version": "1.0.0"
+		},
+		{
+			"type": "panel",
+			"id": "stat",
+			"name": "Stat",
+			"version": ""
+		}
+	],
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": "-- Grafana --",
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"target": {
+					"limit": 100,
+					"matchAny": false,
+					"tags": [],
+					"type": "dashboard"
+				},
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"gnetId": null,
+	"graphTooltip": 0,
+	"id": null,
+	"iteration": 1655915159751,
+	"links": [],
+	"panels": [
+		{
+			"collapsed": true,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 22,
+			"panels": [
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "dateTimeAsIso"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 2,
+						"y": 1
+					},
+					"id": 2,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "none",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "(process_start_time_seconds{instance=\"$instance\"})*1000",
+							"interval": "",
+							"legendFormat": "{{instance}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Up since",
+					"type": "stat"
+				},
+				{
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"displayName": "",
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									}
+								]
+							},
+							"unit": "decbytes"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 7,
+						"y": 1
+					},
+					"id": 4,
+					"options": {
+						"orientation": "auto",
+						"reduceOptions": {
+							"calcs": ["mean"],
+							"fields": "",
+							"values": false
+						},
+						"showThresholdLabels": false,
+						"showThresholdMarkers": false,
+						"text": {}
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "process_resident_memory_bytes{instance=\"$instance\"}",
+							"format": "time_series",
+							"interval": "",
+							"intervalFactor": 3,
+							"legendFormat": "{{instance}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Average Mem Usage",
+					"transparent": true,
+					"type": "gauge"
+				},
+				{
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"mappings": [],
+							"max": 100,
+							"min": 0,
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 50
+									}
+								]
+							},
+							"unit": "percent"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 12,
+						"y": 1
+					},
+					"id": 6,
+					"options": {
+						"orientation": "auto",
+						"reduceOptions": {
+							"calcs": ["mean"],
+							"fields": "",
+							"values": false
+						},
+						"showThresholdLabels": false,
+						"showThresholdMarkers": true,
+						"text": {}
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "rate(process_cpu_seconds_total{instance=\"$instance\"}[$__interval])*100",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{instance}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Average CPU Usage",
+					"transparent": true,
+					"type": "gauge"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "none"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 17,
+						"y": 1
+					},
+					"id": 20,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "process_max_fds{instance=\"$instance\"}",
+							"interval": "",
+							"legendFormat": "{{instance}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Process Max FDs",
+					"type": "stat"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "none"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 2,
+						"y": 10
+					},
+					"id": 11,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["sum"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "sum(increase(cs_filesource_hits_total{instance=\"$instance\"}[$__interval]) or up * 0) + sum(increase(cs_cloudwatch_stream_hits_total{instance=\"$instance\"}[$__interval]) or up * 0) + sum(increase(cs_journalctlsource_hits_total{instance=\"$instance\"}[$__interval]) or up * 0) + sum(increase(cs_syslogsource_hits_total{instance=\"$instance\"}[$__interval]) or up * 0)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Total raw lines",
+					"type": "stat"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "none"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 7,
+						"y": 10
+					},
+					"id": 12,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["sum"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "sum(increase(cs_parser_hits_ok_total{instance=\"$instance\"}[$__interval]))",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Total parsed lines",
+					"type": "stat"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "short"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 12,
+						"y": 10
+					},
+					"id": 8,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["sum"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "sum(increase(cs_bucket_overflowed_total{instance=\"$instance\"}[$__interval]))",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Total Overflows",
+					"type": "stat"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "none"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 17,
+						"y": 10
+					},
+					"id": 18,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["lastNotNull"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "process_open_fds{instance=\"$instance\"}",
+							"interval": "",
+							"legendFormat": "{{instance}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Process Open FDs",
+					"type": "stat"
+				},
+				{
+					"cacheTimeout": null,
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"color": {
+								"mode": "thresholds"
+							},
+							"mappings": [
+								{
+									"options": {
+										"match": "null",
+										"result": {
+											"text": "N/A"
+										}
+									},
+									"type": "special"
+								}
+							],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									},
+									{
+										"color": "red",
+										"value": 80
+									}
+								]
+							},
+							"unit": "none"
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 5,
+						"x": 4,
+						"y": 19
+					},
+					"id": 14,
+					"interval": null,
+					"links": [],
+					"maxDataPoints": 100,
+					"options": {
+						"colorMode": "background",
+						"graphMode": "none",
+						"justifyMode": "auto",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["sum"],
+							"fields": "",
+							"values": false
+						},
+						"text": {},
+						"textMode": "auto"
+					},
+					"pluginVersion": "8.1.2",
+					"targets": [
+						{
+							"expr": "sum(increase(cs_parser_hits_ko_total{instance=\"$instance\"}[$__interval]))",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Total unparsed lines",
+					"type": "stat"
+				},
+				{
+					"datasource": "${DS_PROMETHEUS}",
+					"fieldConfig": {
+						"defaults": {
+							"mappings": [],
+							"thresholds": {
+								"mode": "absolute",
+								"steps": [
+									{
+										"color": "green",
+										"value": null
+									}
+								]
+							}
+						},
+						"overrides": []
+					},
+					"gridPos": {
+						"h": 9,
+						"w": 10,
+						"x": 9,
+						"y": 19
+					},
+					"id": 16,
+					"options": {
+						"displayMode": "gradient",
+						"orientation": "horizontal",
+						"reduceOptions": {
+							"calcs": ["sum"],
+							"fields": "",
+							"values": false
+						},
+						"showUnfilled": false,
+						"text": {}
+					},
+					"pluginVersion": "8.1.2",
+					"repeat": null,
+					"repeatDirection": "v",
+					"targets": [
+						{
+							"exemplar": true,
+							"expr": "sum(increase(cs_bucket_overflowed_total{instance=\"$instance\"}[$__interval])) by (name)",
+							"format": "time_series",
+							"instant": false,
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"timeFrom": null,
+					"timeShift": null,
+					"title": "Top scenarios",
+					"transparent": true,
+					"type": "bargauge"
+				}
+			],
+			"repeat": "instance",
+			"title": "$instance",
+			"type": "row"
+		}
+	],
+	"schemaVersion": 30,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"allValue": null,
+				"current": {},
+				"datasource": "${DS_PROMETHEUS}",
+				"definition": "label_values(cs_info, instance)",
+				"description": null,
+				"error": null,
+				"hide": 0,
+				"includeAll": true,
+				"label": "instance",
+				"multi": true,
+				"name": "instance",
+				"options": [],
+				"query": {
+					"query": "label_values(cs_info, instance)",
+					"refId": "Prometheus-instance-Variable-Query"
+				},
+				"refresh": 1,
+				"regex": "",
+				"skipUrlSync": false,
+				"sort": 1,
+				"tagValuesQuery": "",
+				"tagsQuery": "",
+				"type": "query",
+				"useTags": false
+			}
+		]
+	},
+	"time": {
+		"from": "now-24h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+	},
+	"timezone": "",
+	"title": "Crowdsec Insight",
+	"uid": "e7sWOBVnk",
+	"version": 8
+}

--- a/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-lapi.json
+++ b/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-lapi.json
@@ -1,0 +1,531 @@
+{
+	"__inputs": [
+		{
+			"name": "DS_PROMETHEUS",
+			"label": "Prometheus",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "prometheus",
+			"pluginName": "Prometheus"
+		}
+	],
+	"__requires": [
+		{
+			"type": "panel",
+			"id": "bargauge",
+			"name": "Bar gauge",
+			"version": ""
+		},
+		{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "8.1.2"
+		},
+		{
+			"type": "datasource",
+			"id": "prometheus",
+			"name": "Prometheus",
+			"version": "1.0.0"
+		}
+	],
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": "-- Grafana --",
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"target": {
+					"limit": 100,
+					"matchAny": false,
+					"tags": [],
+					"type": "dashboard"
+				},
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"gnetId": null,
+	"graphTooltip": 0,
+	"id": null,
+	"iteration": 1655915193937,
+	"links": [],
+	"panels": [
+		{
+			"collapsed": false,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 10,
+			"panels": [],
+			"title": "Agents",
+			"type": "row"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 1
+			},
+			"id": 2,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "vertical",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"repeat": "query0",
+			"repeatDirection": "h",
+			"targets": [
+				{
+					"exemplar": false,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint=\"/v1/watchers/login\", instance=\"$lapi\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Agents Login",
+			"type": "heatmap"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							}
+						]
+					},
+					"unit": "none"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 1
+			},
+			"id": 6,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint=\"/v1/watchers/login\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Heartbeat",
+			"type": "heatmap"
+		},
+		{
+			"collapsed": false,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 9
+			},
+			"id": 12,
+			"panels": [],
+			"title": "Decisions",
+			"type": "row"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 10
+			},
+			"id": 4,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint= \"/v1/decisions\", instance=\"$lapi\", method=~\"(GET)|(HEAD)\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions GET (live)",
+			"type": "heatmap"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 10
+			},
+			"id": 13,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint= \"/v1/decisions/stream\", instance=\"$lapi\", method=~\"(GET)|(HEAD)\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions GET (stream)",
+			"type": "heatmap"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 18
+			},
+			"id": 8,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint=~\"/v1/decisions.*\", instance=\"$lapi\", method=\"DELETE\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions DELETE",
+			"type": "heatmap"
+		},
+		{
+			"collapsed": false,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 26
+			},
+			"id": 15,
+			"panels": [],
+			"title": "Alerts",
+			"type": "row"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 27
+			},
+			"id": 17,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint=\"/v1/alerts\",instance=\"$lapi\",method=\"POST\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Alerts POST",
+			"type": "heatmap"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 27
+			},
+			"id": 18,
+			"options": {
+				"displayMode": "gradient",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"showUnfilled": false,
+				"text": {}
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(rate(cs_lapi_request_duration_seconds_bucket{endpoint=\"/v1/alerts\",instance=\"$lapi\",method=~\"(GET)|(HEAD)\"}[$__rate_interval])) by (le)",
+					"format": "heatmap",
+					"interval": "",
+					"legendFormat": "{{le}}",
+					"refId": "A"
+				}
+			],
+			"title": "Alerts GET",
+			"type": "heatmap"
+		}
+	],
+	"schemaVersion": 30,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+		"list": [
+			{
+				"allValue": null,
+				"current": {},
+				"datasource": "${DS_PROMETHEUS}",
+				"definition": "label_values(cs_info, instance)",
+				"description": null,
+				"error": null,
+				"hide": 0,
+				"includeAll": false,
+				"label": null,
+				"multi": false,
+				"name": "lapi",
+				"options": [],
+				"query": {
+					"query": "label_values(cs_info, instance)",
+					"refId": "StandardVariableQuery"
+				},
+				"refresh": 1,
+				"regex": "",
+				"skipUrlSync": false,
+				"sort": 0,
+				"type": "query"
+			}
+		]
+	},
+	"time": {
+		"from": "now-6h",
+		"to": "now"
+	},
+	"timepicker": {},
+	"timezone": "",
+	"title": "LAPI Metrics",
+	"uid": "ofdKJG37k",
+	"version": 11
+}

--- a/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-overview.json
+++ b/deployment/monitoring/grafana/provisioning/dashboards/crowdsec-overview.json
@@ -1,0 +1,1346 @@
+{
+	"__inputs": [
+		{
+			"name": "DS_PROMETHEUS",
+			"label": "Prometheus",
+			"description": "",
+			"type": "datasource",
+			"pluginId": "prometheus",
+			"pluginName": "Prometheus"
+		}
+	],
+	"__requires": [
+		{
+			"type": "grafana",
+			"id": "grafana",
+			"name": "Grafana",
+			"version": "8.1.2"
+		},
+		{
+			"type": "panel",
+			"id": "graph",
+			"name": "Graph (old)",
+			"version": ""
+		},
+		{
+			"type": "datasource",
+			"id": "prometheus",
+			"name": "Prometheus",
+			"version": "1.0.0"
+		},
+		{
+			"type": "panel",
+			"id": "stat",
+			"name": "Stat",
+			"version": ""
+		},
+		{
+			"type": "panel",
+			"id": "timeseries",
+			"name": "Time series",
+			"version": ""
+		}
+	],
+	"annotations": {
+		"list": [
+			{
+				"builtIn": 1,
+				"datasource": "-- Grafana --",
+				"enable": true,
+				"hide": true,
+				"iconColor": "rgba(0, 211, 255, 1)",
+				"name": "Annotations & Alerts",
+				"target": {
+					"limit": 100,
+					"matchAny": false,
+					"tags": [],
+					"type": "dashboard"
+				},
+				"type": "dashboard"
+			}
+		]
+	},
+	"editable": true,
+	"gnetId": null,
+	"graphTooltip": 0,
+	"id": null,
+	"links": [],
+	"panels": [
+		{
+			"collapsed": false,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 0
+			},
+			"id": 24,
+			"panels": [],
+			"title": "Summary",
+			"type": "row"
+		},
+		{
+			"cacheTimeout": null,
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [
+						{
+							"options": {
+								"match": "null",
+								"result": {
+									"text": "N/A"
+								}
+							},
+							"type": "special"
+						}
+					],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "#E02F44",
+								"value": null
+							},
+							{
+								"color": "#E02F44",
+								"value": 10
+							},
+							{
+								"color": "#299c46",
+								"value": 10
+							}
+						]
+					},
+					"unit": "none"
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 8,
+				"w": 6,
+				"x": 0,
+				"y": 1
+			},
+			"id": 2,
+			"interval": null,
+			"links": [],
+			"maxDataPoints": 100,
+			"options": {
+				"colorMode": "background",
+				"graphMode": "none",
+				"justifyMode": "auto",
+				"orientation": "horizontal",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "count(cs_info)",
+					"interval": "",
+					"legendFormat": "",
+					"refId": "A"
+				}
+			],
+			"timeFrom": null,
+			"timeShift": null,
+			"title": "Running Crowdsec",
+			"transparent": true,
+			"type": "stat"
+		},
+		{
+			"aliasColors": {},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": "${DS_PROMETHEUS}",
+			"decimals": 1,
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 8,
+				"w": 18,
+				"x": 6,
+				"y": 1
+			},
+			"hiddenSeries": false,
+			"id": 8,
+			"legend": {
+				"alignAsTable": true,
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"rightSide": true,
+				"show": true,
+				"sort": "total",
+				"sortDesc": true,
+				"total": true,
+				"values": true
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "null",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "8.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(increase(cs_filesource_hits_total[$__interval])) by (instance)",
+					"interval": "",
+					"intervalFactor": 2,
+					"legendFormat": "{{instance}}",
+					"refId": "A"
+				},
+				{
+					"exemplar": true,
+					"expr": "sum(increase(cs_journalctlsource_hits_total[$__interval])) by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{instance}}",
+					"refId": "B"
+				},
+				{
+					"exemplar": true,
+					"expr": "sum(increase(cs_cloudwatch_stream_hits_total[$__interval])) by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{instance}}",
+					"refId": "C"
+				},
+				{
+					"exemplar": true,
+					"expr": "sum(increase(cs_syslogsource_hits_total[$__interval])) by (instance)",
+					"hide": false,
+					"interval": "",
+					"legendFormat": "{{instance}}",
+					"refId": "D"
+				}
+			],
+			"thresholds": [],
+			"timeFrom": null,
+			"timeRegions": [],
+			"timeShift": null,
+			"title": "Acquisitions",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				},
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false,
+				"alignLevel": null
+			}
+		},
+		{
+			"aliasColors": {},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": "${DS_PROMETHEUS}",
+			"decimals": 1,
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 0,
+				"y": 9
+			},
+			"hiddenSeries": false,
+			"id": 10,
+			"legend": {
+				"alignAsTable": true,
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"rightSide": true,
+				"show": true,
+				"sort": "total",
+				"sortDesc": true,
+				"total": true,
+				"values": true
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "null",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "8.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"expr": "sum(increase(cs_parser_hits_total[$__interval])) by (instance)",
+					"interval": "",
+					"intervalFactor": 2,
+					"legendFormat": "{{instance}}",
+					"refId": "A"
+				}
+			],
+			"thresholds": [],
+			"timeFrom": null,
+			"timeRegions": [],
+			"timeShift": null,
+			"title": "Parsers",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				},
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false,
+				"alignLevel": null
+			}
+		},
+		{
+			"aliasColors": {},
+			"bars": false,
+			"dashLength": 10,
+			"dashes": false,
+			"datasource": "${DS_PROMETHEUS}",
+			"decimals": 1,
+			"fieldConfig": {
+				"defaults": {
+					"links": []
+				},
+				"overrides": []
+			},
+			"fill": 1,
+			"fillGradient": 0,
+			"gridPos": {
+				"h": 8,
+				"w": 12,
+				"x": 12,
+				"y": 9
+			},
+			"hiddenSeries": false,
+			"id": 12,
+			"legend": {
+				"alignAsTable": true,
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"rightSide": true,
+				"show": true,
+				"sort": "total",
+				"sortDesc": true,
+				"total": true,
+				"values": true
+			},
+			"lines": true,
+			"linewidth": 1,
+			"nullPointMode": "null",
+			"options": {
+				"alertThreshold": true
+			},
+			"percentage": false,
+			"pluginVersion": "8.1.2",
+			"pointradius": 2,
+			"points": false,
+			"renderer": "flot",
+			"seriesOverrides": [],
+			"spaceLength": 10,
+			"stack": false,
+			"steppedLine": false,
+			"targets": [
+				{
+					"expr": "sum(increase(cs_bucket_overflowed_total[$__interval])) by (instance)",
+					"interval": "",
+					"intervalFactor": 2,
+					"legendFormat": "{{instance}}",
+					"refId": "A"
+				}
+			],
+			"thresholds": [],
+			"timeFrom": null,
+			"timeRegions": [],
+			"timeShift": null,
+			"title": "Buckets overflow",
+			"tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			},
+			"transparent": true,
+			"type": "graph",
+			"xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			},
+			"yaxes": [
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				},
+				{
+					"format": "short",
+					"label": null,
+					"logBase": 1,
+					"max": null,
+					"min": null,
+					"show": true
+				}
+			],
+			"yaxis": {
+				"align": false,
+				"alignLevel": null
+			}
+		},
+		{
+			"collapsed": false,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 17
+			},
+			"id": 30,
+			"panels": [],
+			"title": "Alerts",
+			"type": "row"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 4,
+				"w": 12,
+				"x": 0,
+				"y": 18
+			},
+			"id": 36,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(cs_active_decisions)",
+					"interval": "",
+					"legendFormat": "",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions Count",
+			"type": "stat"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "thresholds"
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 4,
+				"w": 12,
+				"x": 12,
+				"y": 18
+			},
+			"id": 38,
+			"options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+					"calcs": ["lastNotNull"],
+					"fields": "",
+					"values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			},
+			"pluginVersion": "8.1.2",
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(cs_alerts)",
+					"interval": "",
+					"legendFormat": "",
+					"refId": "A"
+				}
+			],
+			"title": "Alerts Count",
+			"type": "stat"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 11,
+				"w": 24,
+				"x": 0,
+				"y": 22
+			},
+			"id": 32,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "table",
+					"placement": "right"
+				},
+				"tooltip": {
+					"mode": "single"
+				}
+			},
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(cs_active_decisions) by (reason)",
+					"interval": "",
+					"legendFormat": "{{reason}}",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions by scenario",
+			"type": "timeseries"
+		},
+		{
+			"datasource": "${DS_PROMETHEUS}",
+			"fieldConfig": {
+				"defaults": {
+					"color": {
+						"mode": "palette-classic"
+					},
+					"custom": {
+						"axisLabel": "",
+						"axisPlacement": "auto",
+						"barAlignment": 0,
+						"drawStyle": "line",
+						"fillOpacity": 0,
+						"gradientMode": "none",
+						"hideFrom": {
+							"legend": false,
+							"tooltip": false,
+							"viz": false
+						},
+						"lineInterpolation": "linear",
+						"lineWidth": 1,
+						"pointSize": 5,
+						"scaleDistribution": {
+							"type": "linear"
+						},
+						"showPoints": "auto",
+						"spanNulls": false,
+						"stacking": {
+							"group": "A",
+							"mode": "none"
+						},
+						"thresholdsStyle": {
+							"mode": "off"
+						}
+					},
+					"mappings": [],
+					"thresholds": {
+						"mode": "absolute",
+						"steps": [
+							{
+								"color": "green",
+								"value": null
+							},
+							{
+								"color": "red",
+								"value": 80
+							}
+						]
+					}
+				},
+				"overrides": []
+			},
+			"gridPos": {
+				"h": 9,
+				"w": 24,
+				"x": 0,
+				"y": 33
+			},
+			"id": 34,
+			"options": {
+				"legend": {
+					"calcs": [],
+					"displayMode": "list",
+					"placement": "bottom"
+				},
+				"tooltip": {
+					"mode": "single"
+				}
+			},
+			"targets": [
+				{
+					"exemplar": true,
+					"expr": "sum(cs_active_decisions) by (action)",
+					"interval": "",
+					"legendFormat": "{{action}}",
+					"refId": "A"
+				}
+			],
+			"title": "Decisions By Type",
+			"type": "timeseries"
+		},
+		{
+			"collapsed": true,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 42
+			},
+			"id": 26,
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": "${DS_PROMETHEUS}",
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 9,
+						"w": 12,
+						"x": 0,
+						"y": 3
+					},
+					"hiddenSeries": false,
+					"id": 4,
+					"interval": "",
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.1.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "sum(increase(cs_node_hits_ok_total[$__interval])) by (name)",
+							"format": "time_series",
+							"instant": false,
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeFrom": null,
+					"timeRegions": [],
+					"timeShift": null,
+					"title": "Parsers ok",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"buckets": null,
+						"mode": "time",
+						"name": null,
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						},
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false,
+						"alignLevel": null
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": "${DS_PROMETHEUS}",
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 9,
+						"w": 12,
+						"x": 12,
+						"y": 3
+					},
+					"hiddenSeries": false,
+					"id": 6,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sideWidth": null,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.1.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "sum(increase(cs_node_hits_ko_total[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeFrom": null,
+					"timeRegions": [],
+					"timeShift": null,
+					"title": "Parsers nok",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"buckets": null,
+						"mode": "time",
+						"name": null,
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						},
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false,
+						"alignLevel": null
+					}
+				}
+			],
+			"title": "Parsers",
+			"type": "row"
+		},
+		{
+			"collapsed": true,
+			"datasource": null,
+			"gridPos": {
+				"h": 1,
+				"w": 24,
+				"x": 0,
+				"y": 43
+			},
+			"id": 28,
+			"panels": [
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": "${DS_PROMETHEUS}",
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 9,
+						"w": 12,
+						"x": 0,
+						"y": 3
+					},
+					"hiddenSeries": false,
+					"id": 18,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.1.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "sum(increase(cs_bucket_created_total[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeFrom": null,
+					"timeRegions": [],
+					"timeShift": null,
+					"title": "Buckets created",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"buckets": null,
+						"mode": "time",
+						"name": null,
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						},
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false,
+						"alignLevel": null
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": "${DS_PROMETHEUS}",
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 8,
+						"w": 12,
+						"x": 12,
+						"y": 3
+					},
+					"hiddenSeries": false,
+					"id": 20,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.1.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "sum(increase(cs_bucket_overflowed_total[$__interval])) by (name)",
+							"interval": "",
+							"intervalFactor": 2,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeFrom": null,
+					"timeRegions": [],
+					"timeShift": null,
+					"title": "Buckets overflow",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"buckets": null,
+						"mode": "time",
+						"name": null,
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						},
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false,
+						"alignLevel": null
+					}
+				},
+				{
+					"aliasColors": {},
+					"bars": false,
+					"dashLength": 10,
+					"dashes": false,
+					"datasource": "${DS_PROMETHEUS}",
+					"decimals": 1,
+					"fieldConfig": {
+						"defaults": {
+							"links": []
+						},
+						"overrides": []
+					},
+					"fill": 1,
+					"fillGradient": 0,
+					"gridPos": {
+						"h": 9,
+						"w": 24,
+						"x": 0,
+						"y": 12
+					},
+					"hiddenSeries": false,
+					"id": 22,
+					"legend": {
+						"alignAsTable": true,
+						"avg": false,
+						"current": false,
+						"max": false,
+						"min": false,
+						"rightSide": true,
+						"show": true,
+						"sort": "total",
+						"sortDesc": true,
+						"total": true,
+						"values": true
+					},
+					"lines": true,
+					"linewidth": 1,
+					"nullPointMode": "null",
+					"options": {
+						"alertThreshold": true
+					},
+					"percentage": false,
+					"pluginVersion": "8.1.2",
+					"pointradius": 2,
+					"points": false,
+					"renderer": "flot",
+					"seriesOverrides": [],
+					"spaceLength": 10,
+					"stack": false,
+					"steppedLine": false,
+					"targets": [
+						{
+							"expr": "sum(cs_buckets) by (name)",
+							"interval": "",
+							"intervalFactor": 1,
+							"legendFormat": "{{name}}",
+							"refId": "A"
+						}
+					],
+					"thresholds": [],
+					"timeFrom": null,
+					"timeRegions": [],
+					"timeShift": null,
+					"title": "Buckets Timeline",
+					"tooltip": {
+						"shared": true,
+						"sort": 0,
+						"value_type": "individual"
+					},
+					"transparent": true,
+					"type": "graph",
+					"xaxis": {
+						"buckets": null,
+						"mode": "time",
+						"name": null,
+						"show": true,
+						"values": []
+					},
+					"yaxes": [
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						},
+						{
+							"format": "short",
+							"label": null,
+							"logBase": 1,
+							"max": null,
+							"min": null,
+							"show": true
+						}
+					],
+					"yaxis": {
+						"align": false,
+						"alignLevel": null
+					}
+				}
+			],
+			"title": "Buckets",
+			"type": "row"
+		}
+	],
+	"refresh": false,
+	"schemaVersion": 30,
+	"style": "dark",
+	"tags": [],
+	"templating": {
+		"list": []
+	},
+	"time": {
+		"from": "now-24h",
+		"to": "now"
+	},
+	"timepicker": {
+		"refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+	},
+	"timezone": "",
+	"title": "Crowdsec Overview",
+	"uid": "hjmZdB4nk",
+	"version": 7
+}

--- a/deployment/monitoring/prometheus/prometheus.yml
+++ b/deployment/monitoring/prometheus/prometheus.yml
@@ -57,3 +57,10 @@ scrape_configs:
     relabel_configs:
       - target_label: env
         replacement: production
+
+  - job_name: crowdsec
+    static_configs:
+      - targets: [ 'crowdsec:6060' ]
+        labels:
+          env: production
+    metrics_path: /metrics

--- a/deployment/traefik/crowdsec/profiles.yaml
+++ b/deployment/traefik/crowdsec/profiles.yaml
@@ -1,8 +1,7 @@
-# Override default ban duration (default is 4h — too harsh for false positives).
-- name: default_ip_remediation
-  filters:
-    - Alert.Remediation == true && Alert.GetScope() == "Ip"
-  decisions:
-    - type: ban
-      duration: 30m
-  on_success: break
+name: default_ip_remediation
+filters:
+  - Alert.Remediation == true && Alert.GetScope() == "Ip"
+decisions:
+  - type: ban
+    duration: 30m
+on_success: break

--- a/deployment/traefik/crowdsec/profiles.yaml
+++ b/deployment/traefik/crowdsec/profiles.yaml
@@ -1,0 +1,8 @@
+# Override default ban duration (default is 4h — too harsh for false positives).
+- name: default_ip_remediation
+  filters:
+    - Alert.Remediation == true && Alert.GetScope() == "Ip"
+  decisions:
+    - type: ban
+      duration: 30m
+  on_success: break

--- a/deployment/traefik/docker-compose.traefik.yml
+++ b/deployment/traefik/docker-compose.traefik.yml
@@ -116,6 +116,7 @@ services:
       - crowdsec-config-volume:/etc/crowdsec
       - traefik-logs-volume:/var/log/traefik:ro
       - ./crowdsec/acquis.yml:/etc/crowdsec/acquis.d/traefik.yml:ro
+      - ./crowdsec/profiles.yaml:/etc/crowdsec/profiles.yaml:ro
     networks:
       - traefik-network
       - alloy-network

--- a/deployment/traefik/docker-compose.traefik.yml
+++ b/deployment/traefik/docker-compose.traefik.yml
@@ -118,6 +118,7 @@ services:
       - ./crowdsec/acquis.yml:/etc/crowdsec/acquis.d/traefik.yml:ro
     networks:
       - traefik-network
+      - alloy-network
     healthcheck:
       test: [ 'CMD', 'cscli', 'version' ]
       interval: 30s

--- a/deployment/traefik/dynamic.yml
+++ b/deployment/traefik/dynamic.yml
@@ -52,6 +52,7 @@ http:
           crowdsecAppsecHost: crowdsec:7422
           crowdsecAppsecFailureBlock: true
           crowdsecAppsecUnreachableBlock: false
+          crowdsecLapiUnreachableBlock: false
 
 # ------------------------------------------------------------------------------
 # TLS options — 'default' is applied automatically to all routers


### PR DESCRIPTION
## Summary

- Add `crowdsecLapiUnreachableBlock: false` to `dynamic.yml` to prevent 403s during the startup race between Traefik and CrowdSec LAPI
- Mount custom `profiles.yaml` to reduce ban duration from 4h → 30m, limiting false-positive impact on normal users filtering courses
- Add CrowdSec Prometheus scrape config + Grafana dashboards for observability

## Post-deploy step (manual, run once on VPS)

Remove the `http-crawl-non_statics` scenario which fires on heavy course filtering:
```bash
docker exec global-crowdsec-1 cscli scenarios remove crowdsecurity/http-crawl-non_statics --force
```

## Test plan

- [ ] Deploy Traefik stack and confirm no startup 403s on main site
- [ ] Confirm CrowdSec bans expire after 30m (`cscli decisions list`)
- [ ] Run the scenario removal command above

🤖 Generated with [Claude Code](https://claude.com/claude-code)